### PR TITLE
Filter module specifiers

### DIFF
--- a/lib/es/Declaration.ts
+++ b/lib/es/Declaration.ts
@@ -7,17 +7,17 @@ export type Interface = (ExportAllDeclaration | ExportNamedDeclaration) | Import
 export type IOptions<T extends Interface> = IBaseOptions<T>;
 
 export default class Declaration<T extends Interface> extends Base<T> {
-  constructor({ declaration, ...rest}: IOptions<T>) {
+  constructor({ declaration, file, ...rest}: IOptions<T>) {
     // RAII checks
     const { type, value } = (declaration.source as SimpleLiteral);
     if (type !== 'Literal') {
-      throw new TypeError(`Invalid ES declaration source type: ${type}`);
+      throw new TypeError(`Invalid ES declaration source type '${type}' in '${file.source}'`);
     }
     if (typeof value !== 'string') {
-      throw new TypeError(`The type of the ES source value was not a 'string': ${typeof value}`);
+      throw new TypeError(`The type '${typeof value}' of the ES source value was not a 'string' for '${file.source}'`);
     }
 
-    super({declaration, ...rest, path: value});
+    super({declaration, file, ...rest, path: value});
   }
 
   private get literal(): SimpleLiteral {

--- a/lib/ts/Declaration.ts
+++ b/lib/ts/Declaration.ts
@@ -7,15 +7,17 @@ export type Interface = ExportDeclaration | ImportDeclaration;
 export type IOptions<T extends Interface> = IBaseOptions<T>;
 
 export default class Declaration<T extends Interface> extends Base<T> {
-  constructor({ declaration, ...rest}: IOptions<T>) {
-
+  constructor({ declaration, file, ...rest}: IOptions<T>) {
     // RAII checks
+    if (!declaration.moduleSpecifier) {
+      throw new TypeError(`No TS module specifier in '${file.source}'`);
+    }
     const { kind, text } = (declaration.moduleSpecifier as StringLiteral);
     if (kind !== SyntaxKind.StringLiteral) {
-      throw new TypeError(`Invalid TS declaration source type: ${kind}`);
+      throw new TypeError(`Invalid TS declaration literal kind '${kind}' in '${file.source}'`);
     }
 
-    super({declaration, ...rest, path: text});
+    super({declaration, file, ...rest, path: text});
   }
 
   private get literal(): StringLiteral {

--- a/lib/ts/File.ts
+++ b/lib/ts/File.ts
@@ -59,6 +59,7 @@ export default class File extends Base<Import, Export> {
     const { statements } = await this.ast;
     yield* statements
       .filter(({kind}) => kind === SyntaxKind.ExportDeclaration)
+      .filter(n => (n as ExportDeclaration).moduleSpecifier)
       .map(n => new Export({file: this, declaration: n as ExportDeclaration}));
   }
 


### PR DESCRIPTION
An `export { Type };` will not have a `moduleSpecifier`, so we can ignore them.